### PR TITLE
Remove server-side caching from get-archives API

### DIFF
--- a/src/app/api/get-archives/route.ts
+++ b/src/app/api/get-archives/route.ts
@@ -49,11 +49,11 @@ export async function GET(req: Request) {
       creator_username: row.creator_username,
     }));
 
-    // Add caching headers - cache for 5 minutes, revalidate in background
+    // No caching - always return fresh data
     return NextResponse.json({ archives }, {
       status: 200,
       headers: {
-        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+        'Cache-Control': 'no-store, no-cache, must-revalidate',
       },
     });
   } catch (error) {


### PR DESCRIPTION
## Fix: Remove API-level caching

### The Real Problem
The get-archives API was caching responses for 5 minutes on the server side. Even though we fixed frontend caching, the API itself was returning stale data.

### What Changed
- Changed `Cache-Control` from `public, s-maxage=300, stale-while-revalidate=600` to `no-store, no-cache, must-revalidate`
- API now always queries the database for fresh data
- Deleted archives will immediately disappear from the page

### Testing
1. Wait for deployment
2. Hard refresh the archives page (Ctrl+Shift+R or Cmd+Shift+R)
3. Archives should now be empty (database was already cleared)
4. Add a test archive
5. Delete it - should immediately disappear

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author